### PR TITLE
Add TLS certs for exposing Docker. Fix preliminaries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Docker is set up entirely using Ansible. The `docker` role is an adaptation of [
 2. Run the playbook with `ansible-playbook -i hosts main.yml`
 
 ## TODO
-* *Safely* expose the Docker daemon (TLS certificate)
+* Add modularity via `defaults` (e.g. for certs' and keys' filenames)
+* Parametrize the copy of certs and keys from `docker-tls.yml` per host
 * Improve the way Docker Swarm is deployed
 * Test tasks with Molecule
 * Remove conditional `{{ manager_ip }}` in Docker swarm setup

--- a/roles/docker/defaults/main.yml
+++ b/roles/docker/defaults/main.yml
@@ -28,5 +28,10 @@ docker_cron_jobs:
     cron_file: "docker-disk-clean-up"
     user: "{{ (docker_users | first) | d('root') }}"
 
-# IP of the manager node
+# IP of the manager node, as per the Vagrantfile
 manager_ip: "192.168.33.10"
+
+# Local destination folders for the copied TLS certs and RSA keys
+# certs_folder: "/etc/ssl/certs/"
+certs_folder: "/tmp/"
+keys_folder: "/tmp/"

--- a/roles/docker/tasks/docker-expose-api.yml
+++ b/roles/docker/tasks/docker-expose-api.yml
@@ -13,7 +13,13 @@
     content: |
         [Service]
         ExecStart=
-        ExecStart=/usr/bin/dockerd -H tcp://0.0.0.0:2375 -H unix:///var/run/docker.sock
+        ExecStart=/usr/bin/dockerd \
+                  --tlsverify \
+                  --tlscacert=/etc/ssl/certs/ca-ansible.crt \
+                  --tlscert=/etc/ssl/certs/server-cert.crt \
+                  --tlskey=/etc/ssl/private/server-key.pem \
+                  -H tcp://0.0.0.0:2376 \
+                  -H unix:///var/run/docker.sock
 
 - name: Reload daemon and restart Docker service
   systemd:

--- a/roles/docker/tasks/docker-swarm.yml
+++ b/roles/docker/tasks/docker-swarm.yml
@@ -1,14 +1,4 @@
 ---
-- name: Install python3
-  yum:
-    update_cache: yes
-    name: python3
-    state: present
-
-- name: Install Docker via Pip
-  pip:
-    name: docker
-
 - name: Include task to set up the swarm's manager
   include_tasks: docker-swarm-manager.yml
   when: "'{{ manager_ip }}' in ansible_all_ipv4_addresses"

--- a/roles/docker/tasks/docker-tls.yml
+++ b/roles/docker/tasks/docker-tls.yml
@@ -1,0 +1,124 @@
+---
+- name: Create necessary folders for keys and certificates
+  file:
+    path: "/etc/ssl/{{ item }}"
+    state: directory
+    mode: '0755'
+  loop:
+    - private
+    - certs
+    - csr
+
+- name: Generate an RSA 4096bit private key for the CA
+  openssl_privatekey:
+    path: /etc/ssl/private/ca-key.pem
+
+- name: Generate an OpenSSL Certificate Signing Request for the CA
+  openssl_csr:
+    path: /etc/ssl/csr/ca.csr
+    privatekey_path: /etc/ssl/private/ca-key.pem
+    common_name: "{{ inventory_hostname }}"
+    basic_constraints: "CA:TRUE"
+    mode: 0666
+
+- name: Generate a self-signed certificate for the CA
+  openssl_certificate:
+    path: /etc/ssl/certs/ca-ansible.crt
+    privatekey_path: /etc/ssl/private/ca-key.pem
+    csr_path: /etc/ssl/csr/ca.csr
+    provider: selfsigned
+    mode: 0666
+
+- name: Generate an RSA 4096bit private key for the server
+  openssl_privatekey:
+    path: /etc/ssl/private/server-key.pem
+
+- name: Get the current host's set of IPs
+  set_fact:
+    subjectAltName: "DNS:{{ inventory_hostname }},IP:{{ ansible_all_ipv4_addresses | join(',IP:') }}"
+
+- name: Generate an OpenSSL Certificate Signing Request for the server
+  openssl_csr:
+    path: /etc/ssl/csr/server.csr
+    privatekey_path: /etc/ssl/private/server-key.pem
+    extended_key_usage: serverAuth
+    common_name: "{{ inventory_hostname }}"
+    subject_alt_name: "{{ subjectAltName }}"
+    mode: 0666
+
+- name: Generate the signed certificate for the server
+  openssl_certificate:
+    path: /etc/ssl/certs/server-cert.crt
+    csr_path: /etc/ssl/csr/server.csr
+    privatekey_path: /etc/ssl/private/server-key.pem
+    provider: ownca
+    ownca_path: /etc/ssl/certs/ca-ansible.crt
+    ownca_privatekey_path: /etc/ssl/private/ca-key.pem
+    mode: 0666
+
+- name: Generate an RSA 4096bit private key for the client
+  openssl_privatekey:
+    path: /etc/ssl/private/key.pem
+
+- name: Generate an OpenSSL Certificate Signing Request for the client
+  openssl_csr:
+    path: /etc/ssl/csr/client.csr
+    privatekey_path: /etc/ssl/private/key.pem
+    extended_key_usage: clientAuth
+    mode: 0666
+    common_name: "client"
+
+- name: Generate the signed certificate for the client
+  openssl_certificate:
+    path: /etc/ssl/certs/client-cert.crt
+    csr_path: /etc/ssl/csr/client.csr
+    privatekey_path: /etc/ssl/private/key.pem
+    provider: ownca
+    ownca_path: /etc/ssl/certs/ca-ansible.crt
+    ownca_privatekey_path: /etc/ssl/private/ca-key.pem
+    mode: 0666
+
+- name: Delete CSR files
+  file:
+    path: "/etc/ssl/csr/{{ item }}.csr"
+    state: absent
+  loop:
+    - ca
+    - client
+    - server
+
+- name: Secure keys
+  file:
+    path: "/etc/ssl/private/{{ item }}.pem"
+    mode: 0400
+  loop:
+    - ca-key
+    - key
+    - server-key
+
+- name: Secure certificates
+  file:
+    path: "/etc/ssl/certs/{{ item }}.crt"
+    mode: 0444
+  loop:
+    - ca-ansible
+    - client-cert
+    - server-cert
+
+- name: Fetch client files and copy them to local folder
+  fetch:
+    src: "/etc/ssl/certs/{{ item }}.crt"
+    dest: "{{ certs_folder }}"  # FIXME: parametrize per host
+    flat: yes
+  loop:
+    - "ca-ansible"
+    - "client-cert"
+  when: "'{{ manager_ip }}' in ansible_all_ipv4_addresses"  # FIXME
+
+
+- name: Fetch client files and copy them to local folder
+  fetch:
+    src: "/etc/ssl/private/key.pem"
+    dest: "{{ keys_folder }}"  # FIXME: parametrize per host
+    flat: yes
+  when: "'{{ manager_ip }}' in ansible_all_ipv4_addresses"  # FIXME

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -2,12 +2,6 @@
 - include_tasks: docker-init-centos.yml
   when: ansible_distribution == 'CentOS'
 
-- name: Install python3
-  yum:
-    update_cache: yes
-    name: python3
-    state: present
-
 - name: Install Docker via Pip
   pip:
     name: docker
@@ -67,6 +61,9 @@
     - item.state | d("present") != "absent"
     - item.name | d() and item.job | d()
     - item.schedule | d() and item.cron_file | d()
+
+- name: Generate TLS stuff for safely exposing the Docker daemon API
+  include_tasks: docker-tls.yml
 
 - name: Expose Docker daemon API
   include_tasks: docker-expose-api.yml

--- a/roles/preliminaries/tasks/main.yml
+++ b/roles/preliminaries/tasks/main.yml
@@ -1,4 +1,16 @@
 ---
+- name: Install python3
+  yum:
+    update_cache: yes
+    name: python3
+    state: present
+
+- name: Install OpenSSL
+  yum:
+    update_cache: yes
+    name: openssl
+    state: present
+
 - name: Ensure github.com is a known host
   lineinfile:
     dest: /root/.ssh/known_hosts


### PR DESCRIPTION
Also remove two useless steps from `docker-swarm.yml`.

The current TLS setup could use some improvements:
* more modularity via the `defaults`
* copy of certs and keys done on a per-host basis